### PR TITLE
DescaleTarget: Add shifting, cross-conversion support

### DIFF
--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -54,8 +54,8 @@ class DescaleTarget(TargetVals):
                                 If None is passed to the first threshold then the mask won't be binarized. It will also run a Maximum and Inflate call on the mask.
                                 Example: line_mask=(KirschTCanny, Bilinear, 50 / 255, 150 / 255)
         :param fields:          Per-field descaling. Must be a FieldBased object. For example, `fields=FieldBased.TFF`.
-                                This indicates the order the fields get operated in. If FieldBased.PROGRESSIVE is passed,
-                                it defaults to None. Default=None.
+                                This indicates the order the fields get operated in, and whether it needs special attention.
+                                Defaults to checking the input clip for the frameprop.
         :param bbmod_masks:     Specify rows to be bbmod'ed for a clip to generate the masks on. Will probably be useful for the new border param in descale.
     """
     height: float
@@ -92,7 +92,7 @@ class DescaleTarget(TargetVals):
         bits, clip = get_depth(clip), get_y(clip)
         self.height = float(self.height)
 
-        self.fields = FieldBased.from_param(self.fields or FieldBased.from_video(clip), self.generate_clips)
+        self.fields = FieldBased.from_param(self.fields or FieldBased.from_video(clip, True), self.generate_clips)
 
         if not self.width:
             self.width = float(self.height * clip.width / clip.height)

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -1,4 +1,4 @@
-from vstools import vs, core, get_w, get_y, depth, iterate, ColorRange, join, get_depth, FieldBased, FieldBasedT
+from vstools import vs, core, get_y, depth, iterate, ColorRange, join, get_depth, FieldBased, FieldBasedT
 from vskernels import Scaler, ScalerT, Kernel, KernelT, Catrom
 from vsmasktools import EdgeDetectT, EdgeDetect
 from typing import Callable, Sequence, Union
@@ -108,7 +108,6 @@ class DescaleTarget(TargetVals):
 
             self._descale_fields(clip)
             ref_y = self.rescale
-            self.line_mask = self.line_mask or False
         elif self.height.is_integer():
             self.descale = self.kernel.descale(clip, self.width, self.height, (self.shift_top, self.shift_left))
             self.rescale = self.kernel.scale(self.descale, clip.width, clip.height, (-self.shift_top, -self.shift_left))
@@ -148,6 +147,10 @@ class DescaleTarget(TargetVals):
 
             if self.do_post_double is not None:
                 self.line_mask = self.line_mask.std.Inflate()
+
+            if self.fields.is_inter:
+                self.line_mask = iterate(self.line_mask, core.std.Inflate, 3)
+                self.line_mask = iterate(self.line_mask, core.std.Maximum, 3)
 
             self.line_mask = depth(self.line_mask, bits)
 

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -92,8 +92,7 @@ class DescaleTarget(TargetVals):
         bits, clip = get_depth(clip), get_y(clip)
         self.height = float(self.height)
 
-        fb = FieldBased.from_param(self.fields, self.generate_clips)
-        self.fields = fb if fb.is_inter else FieldBased.from_video(clip, func=self.generate_clips)
+        self.fields = FieldBased.from_param(self.fields or FieldBased.from_video(clip), self.generate_clips)
 
         if not self.width:
             self.width = float(self.height * clip.width / clip.height)

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -99,10 +99,7 @@ class DescaleTarget(TargetVals):
             if self.fields is None:
                 self.shift_top = 0.0
             else:
-                self.shift_top = tuple(
-                    0.25 * int(self.width) / clip.height, 0.0,
-                    -0.25 * int(self.width) / clip.height, 0.0
-                )
+                self.shift_top = tuple(self._crossconv_shift(clip), -self._crossconv_shift(clip))
 
         self.shift_left = self.shift_left or 0.0
 
@@ -288,6 +285,9 @@ class DescaleTarget(TargetVals):
 
         self.descale = FieldBased.PROGRESSIVE.apply(self.descale)
         self.rescale = FieldBased.PROGRESSIVE.apply(self.rescale)
+
+    def _crossconv_shift(self, clip: vs.VideoNode) -> float:
+        return 0.25 * int(self.width) / clip.height
 
 DT = DescaleTarget
 

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -51,7 +51,7 @@ class DescaleTarget(TargetVals):
                                 You can also pass a list containing edgemask function, scaler and thresholds to generate the mask on the doubled clip for potential better results.
                                 If None is passed to the first threshold then the mask won't be binarized. It will also run a Maximum and Inflate call on the mask.
                                 Example: line_mask=(KirschTCanny, Bilinear, 50 / 255, 150 / 255)
-        :param field_based:     Per-field descaling. Must be a FieldBased object. For example, `fields=FieldBased.TFF`.
+        :param field_based:     Per-field descaling. Must be a FieldBased object. For example, `field_based=FieldBased.TFF`.
                                 This indicates the order the fields get operated in, and whether it needs special attention.
                                 Defaults to checking the input clip for the frameprop.
         :param bbmod_masks:     Specify rows to be bbmod'ed for a clip to generate the masks on. Will probably be useful for the new border param in descale.
@@ -83,16 +83,16 @@ class DescaleTarget(TargetVals):
         bits, clip = get_depth(clip), get_y(clip)
         self.height = float(self.height)
 
-        self.field_based = FieldBased.from_param(self.fields) or FieldBased.from_video(clip)
+        self.field_based = FieldBased.from_param(self.field_based) or FieldBased.from_video(clip)
 
         if not self.width:
             self.width = float(self.height * clip.width / clip.height)
 
         if self.field_based.is_inter:
             if not self.height.is_integer():
-                raise ValueError("`height` must be an integer if `fields` is not None, not float.")
+                raise ValueError("DescaleTarget: `height` must be an integer if `field_based` is not None, not float.")
             if not self.width.is_integer():
-                raise ValueError("`width` must be an integer if `fields` is not None, not float.")
+                raise ValueError("DescaleTarget: `width` must be an integer if `field_based` is not None, not float.")
 
             self._descale_fields(clip)
             ref_y = self.rescale
@@ -198,7 +198,7 @@ class DescaleTarget(TargetVals):
         if self.line_mask != False:
             if isinstance(self.line_mask, Sequence):
                 if len(self.line_mask) < 4:
-                    raise ValueError("DescaleTarget line_mask must contain an Edgemask, Downscaler, lthr and hthr if you passed a list.")
+                    raise ValueError("DescaleTarget: line_mask must contain an Edgemask, Downscaler, lthr and hthr if you passed a list.")
                 mask_fun = EdgeDetect.ensure_obj(self.line_mask[0])
                 if self.line_mask[2] is None:
                     mask = mask_fun.edgemask(self.doubled, planes=0).std.Maximum().std.Inflate()

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -120,6 +120,7 @@ class DescaleTarget(TargetVals):
 
             self._descale_fields(clip)
             ref_y = self.rescale
+            self.line_mask = self.line_mask or False
         elif self.height.is_integer():
             self.descale = self.kernel.descale(clip, self.width, self.height, (self.shift_top, self.shift_left))
             self.rescale = self.kernel.scale(self.descale, clip.width, clip.height, (-self.shift_top, -self.shift_left))

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -99,7 +99,7 @@ class DescaleTarget(TargetVals):
             if self.fields is None:
                 self.shift_top = 0.0
             else:
-                self.shift_top = tuple(self._crossconv_shift(clip), -self._crossconv_shift(clip))
+                self.shift_top = self.crossconv_shift_calc(clip, int(self.height))
 
         self.shift_left = self.shift_left or 0.0
 
@@ -286,8 +286,18 @@ class DescaleTarget(TargetVals):
         self.descale = FieldBased.PROGRESSIVE.apply(self.descale)
         self.rescale = FieldBased.PROGRESSIVE.apply(self.rescale)
 
-    def _crossconv_shift(self, clip: vs.VideoNode) -> float:
-        return 0.25 * int(self.width) / clip.height
+    @staticmethod
+    def crossconv_shift_calc(clip: vs.VideoNode, native_height: int) -> tuple[float, float]:
+        """Calculate the shift for a regular cross-conversion."""
+        return tuple(
+            0.25 / (clip.height / (native_height / 2))
+            -0.25 / (clip.height / (native_height / 2))
+        )
+
+    @staticmethod
+    def crossconv_shift_calc_irregular(clip: vs.VideoNode, native_height: int) -> float:
+        """Calculate the shift for an irregular cross-conversion."""
+        return 0.25 / (clip.height / native_height)
 
 DT = DescaleTarget
 


### PR DESCRIPTION
This adds the following support:

## Shifting 

(this was mandatory for the cross-conversion code)

- Adds shifting support during integer descaling (params: `shift_top`, `shift_left`)
- Separated to add support for stuff like per-field shifting, as it's not uncommon for fields to be shifted differently.
- If the descale is a cross conversion descale, it will also counter-shift if deemed necessary. 
- Auto-counter-shift functionality does not exist for progressive descales due to it not seeming to really play like I want it to for me. Ask Zewia for help with that later if you care enough about that.

## Cross-conversion support

```py
DescaleTarget(720, Bilinear, fields=FieldBased.TFF, shift_top=(1/12, -1/12)).generate_clips(src)
```

~~comp~~ see later comments for updated comps

- New `fields` parameter. If `None`, check if the input clip is interlaced.
- Set the order of operations. If not set, assume other, regular operations.
- Automatically disable `line_mask` unless the user passes something.
- If no shift is set, automatically calculate it (following zimg default)


Handful of things to double-check (though it *should* mostly work):

- counter-shift calc for progressive descaling. For the time being, the user can counter-shift themselves. This should still automatically work for credit masking, at least.
- ~~Shift presets perhaps? Useful because not all shifts are the same. Could be a class with its own calculation method, idk.~~ [a659b93](https://github.com/Vodes/vodesfunc/pull/7/commits/a659b93d4a83c7009358d9c13de386c816dfe08a) adds these presets. I may try to move these over to either `vskernels` or `vsscale` at a later date, but for now they can live here.
- Double-check shifts for cross-conv reupscaling. Right now, no shifts are passed, with the assumption that the upscale will be accurate enough. This is a bit naive, though.