### PR TITLE
DescaleTarget: Masking updates

### DIFF
--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -1,6 +1,7 @@
 from vstools import vs, core, get_y, depth, iterate, ColorRange, join, get_depth, FieldBased, FieldBasedT
 from vskernels import Scaler, ScalerT, Kernel, KernelT, Catrom
 from vsmasktools import EdgeDetectT, EdgeDetect
+from vsrgtools import gauss_blur
 from typing import Callable, Sequence, Union
 from math import floor
 from dataclasses import dataclass
@@ -139,6 +140,7 @@ class DescaleTarget(TargetVals):
             if self.do_post_double is not None:
                 self.line_mask = self.line_mask.std.Inflate()
 
+            self.line_mask = gauss_blur(self.line_mask, 1.5)
 
             self.line_mask = depth(self.line_mask, bits)
 

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -90,12 +90,15 @@ class DescaleTarget(TargetVals):
 
         if self.field_based.is_inter:
             if not self.height.is_integer():
-                raise ValueError("DescaleTarget: `height` must be an integer if `field_based` is not None, not float.")
+                raise ValueError("DescaleTarget: `height` must be an integer when descaling an interlaced clip, not float.")
             if not self.width.is_integer():
-                raise ValueError("DescaleTarget: `width` must be an integer if `field_based` is not None, not float.")
+                raise ValueError("DescaleTarget: `width` must be an integer when descaling an interlaced clip, not float.")
 
             self._descale_fields(clip)
+
             ref_y = self.rescale
+            clip = FieldBased.PROGRESSIVE.apply(clip)
+            self.line_mask = self.line_mask or False
         elif self.height.is_integer():
             self.descale = self.kernel.descale(clip, self.width, self.height, self.shift)
             self.rescale = self.kernel.scale(self.descale, clip.width, clip.height, self.shift)
@@ -136,9 +139,6 @@ class DescaleTarget(TargetVals):
             if self.do_post_double is not None:
                 self.line_mask = self.line_mask.std.Inflate()
 
-            if self.field_based.is_inter:
-                self.line_mask = iterate(self.line_mask, core.std.Inflate, 3)
-                self.line_mask = iterate(self.line_mask, core.std.Maximum, 3)
 
             self.line_mask = depth(self.line_mask, bits)
 

--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -1,7 +1,6 @@
 from vstools import vs, core, get_y, depth, iterate, ColorRange, join, get_depth, FieldBased, FieldBasedT
 from vskernels import Scaler, ScalerT, Kernel, KernelT, Catrom
 from vsmasktools import EdgeDetectT, EdgeDetect
-from vsrgtools import gauss_blur
 from typing import Callable, Sequence, Union
 from math import floor
 from dataclasses import dataclass
@@ -139,8 +138,6 @@ class DescaleTarget(TargetVals):
 
             if self.do_post_double is not None:
                 self.line_mask = self.line_mask.std.Inflate()
-
-            self.line_mask = gauss_blur(self.line_mask, 1.5)
 
             self.line_mask = depth(self.line_mask, bits)
 


### PR DESCRIPTION
This PR adds the two following changes:

## Remove automatic line masking for cross-converted content

This was too unreliable. It worked well on lineart for the most part, but it missed the lot of fainter details and background lines, especially in brighter scenes. As such, I changed it to no longer automatically create an edgemask. If the user passes an edgemask, this is still respected. To aid in this, the clip is also forced to be set to PROGRESSIVE again so it doesn't accidentally mess up anything.

## Add linemask blurring

It's very common for edgemask to leaves slight gaps on thicker lineart. Blurring can help fill those gaps. 

See:
![](https://cdn.discordapp.com/attachments/708435939378331809/1165669086601162803/image.png?ex=6547b0ef&is=65353bef&hm=59b818dd359d1fa0bff06a8ba7c2af32f533451261f193a9eea2b13ddd5b8322)
![](https://cdn.discordapp.com/attachments/708435939378331809/1165669402134450257/image.png?ex=6547b13a&is=65353c3a&hm=bfc9fae6ff1f24a8514d9df0023a6fb793488f92d74c450b858c0844a4cace39)

Blurring also helps smoothen out the application of the rescaled clip, avoiding any "fast" differences that can look off, both in how dithering/grain gets mangled and any potential slight colour shifts.