### PR TITLE
DescaleTarget: One-directional handling

### DIFF
--- a/vodesfunc/descale.py
+++ b/vodesfunc/descale.py
@@ -181,7 +181,7 @@ class DescaleTarget(TargetVals):
         """
         Generates and returns the fully upscaled & masked & what not clip
         """
-        if self.descale == None or self.rescale == None:
+        if self.descale is None or self.rescale is None:
             self.generate_clips(clip)
 
         bits, y = get_depth(clip), get_y(clip)
@@ -190,7 +190,11 @@ class DescaleTarget(TargetVals):
             self.doubled = self.upscaler.double(self.descale)
         else:
             self.upscaler = Scaler.ensure_obj(self.upscaler)
-            self.doubled = self.upscaler.scale(self.descale, self.descale.width * 2, self.descale.height * 2)
+            self.doubled = self.upscaler.scale(
+                self.descale,
+                self.descale.width * ((self.width != self.input_clip.width) + 1),
+                self.descale.height * ((self.height != self.input_clip.height) + 1)
+            )
 
         if self.do_post_double is not None:
             self.doubled = self.do_post_double(self.doubled)


### PR DESCRIPTION
This should ideally also work with your own Doubler classes, but I don't want to figure that out now. For the time being, I added a simple additional check for whether to supersample in a particular direction or not. The results do not seem quite perfect yet, but are still less destructive. Might be a masking related thing.

source:
![image](https://github.com/Vodes/vodesfunc/assets/42927908/ae9ab98c-d3a9-48f0-ba74-93f32f06ddd3)

before:
![image](https://github.com/Vodes/vodesfunc/assets/42927908/4861778a-2d9a-4220-8a8b-555c2a7fe5dc)


after:
![image](https://github.com/Vodes/vodesfunc/assets/42927908/8130ad30-116a-4835-aab4-fbc6b629131f)


