### PR TITLE
MixedRescale: Apply error mask when calcing error

### DIFF
--- a/vodesfunc/rescale_ext/mixed_rescale.py
+++ b/vodesfunc/rescale_ext/mixed_rescale.py
@@ -33,7 +33,12 @@ class RescBuildMixed(RescaleBase):
             case _:
                 metric = "x y - abs dup 0.015 > swap 0 ?"
 
-        diff = core.std.Expr([depth(self.rescaled, 32), clip], metric)
+        rescaled = depth(self.rescaled, 32)
+
+        if self.errormask_clip is not None:
+            rescaled = rescaled.std.MaskedMerge(clip, self.errormask_clip)
+
+        diff = core.std.Expr([rescaled, clip], metric)
         if self.crop_diff:
             diff = diff.std.Crop(5, 5, 5, 5)
         return diff.std.PlaneStats()


### PR DESCRIPTION
This may seem counterintuitive, since it should pick the best option based on the error, and restoring pixels shouldn't help there. However, testing on a SharpBicubic clip using Bilinear/SharpBicubic/Bicubic(b=100, c=0), it manages to reliably catch SharpBicubic. I think for it to fail the error mask needs to cover basically the full screen, which isn't likely. 

This was tested on an episode title that resulted in SharpBicubic being chosen for a show with mixed Bilinear/SharpBicubic, where the rest of the frame was obviously bilinear. As such, this should be generally useful for stuff like credits covering the entire screen.

Still want to perform further testing before this truly gets merged, but there's an idea.

