### PR TITLE
Update normalize_* imports

### DIFF
--- a/vodesfunc/spikefinder.py
+++ b/vodesfunc/spikefinder.py
@@ -5,11 +5,9 @@ from vstools import (
     get_depth,
     vs,
     FrameRangesN,
-    normalize_ranges_to_list,
-    normalize_list_to_ranges,
     FrameRangeN,
 )
-from stgpytools import SoftRange
+from stgpytools import SoftRange, normalize_ranges_to_list, normalize_list_to_ranges
 from muxtools import get_executable, PathLike, VideoFile, warn, make_output, ensure_path_exists, info, debug
 from vsmuxtools.video.encoders import VideoEncoder
 from dataclasses import dataclass


### PR DESCRIPTION
These were moved from `vstools` to `stgpytools` in the latest release.