### PR TITLE
IgnoreMask: Add ignore_mask support

### DIFF
--- a/vodesfunc/rescale.py
+++ b/vodesfunc/rescale.py
@@ -1,31 +1,33 @@
-from vstools import (
-    vs,
-    core,
-    FunctionUtil,
-    GenericVSFunction,
-    iterate,
-    replace_ranges,
-    FrameRangesN,
-    get_peak_value,
-    FieldBasedT,
-    FieldBased,
-    CustomValueError,
-    get_video_format,
-)
-from vskernels import KernelLike, Kernel, ScalerLike, Bilinear, Hermite, Scaler
+import inspect
+from typing import Self
+
+from vskernels import Bilinear, Hermite, Kernel, KernelLike, Scaler, ScalerLike
 from vsmasktools import EdgeDetectT, KirschTCanny
 from vsrgtools import removegrain
 from vsscale import ArtCNN
-from typing import Self
-import inspect
+from vstools import (
+    CustomValueError,
+    FieldBased,
+    FieldBasedT,
+    FrameRangesN,
+    FunctionUtil,
+    GenericVSFunction,
+    core,
+    get_peak_value,
+    get_video_format,
+    iterate,
+    replace_ranges,
+    vs,
+)
 
 from .rescale_ext import RescBuildFB, RescBuildNonFB
+from .rescale_ext.ignoremask import IgnoreMask
 from .rescale_ext.mixed_rescale import RescBuildMixed
 
 __all__ = ["RescaleBuilder"]
 
 
-class RescaleBuilder(RescBuildFB, RescBuildNonFB, RescBuildMixed):
+class RescaleBuilder(RescBuildFB, RescBuildNonFB, RescBuildMixed, IgnoreMask):
     """
     The fancy new rescale wrapper to make life easier.
     Now 99% less buggy and should handle everything.
@@ -85,6 +87,7 @@ class RescaleBuilder(RescBuildFB, RescBuildNonFB, RescBuildMixed):
         self.kernel = Kernel.ensure_obj(kernel)
         self.border_handling = self.kernel.kwargs.pop("border_handling", 0)
         self.field_based = FieldBased.from_param(field_based) or FieldBased.from_video(clip)
+        self.ignore_mask = self.kernel.kwargs.pop("ignore_mask", None)
 
         self.height = height if "h" in mode else clip.height
         self.width = width if "w" in mode else clip.width

--- a/vodesfunc/rescale_ext/__init__.py
+++ b/vodesfunc/rescale_ext/__init__.py
@@ -1,6 +1,6 @@
-from .mixed_rescale import *
-from .fieldbased_rescale import *
-from .regular_rescale import *
+from . import base, fieldbased_rescale, ignoremask, mixed_rescale, regular_rescale
 from .base import *
-
-from . import base, fieldbased_rescale, regular_rescale, mixed_rescale
+from .fieldbased_rescale import *
+from .ignoremask import *
+from .mixed_rescale import *
+from .regular_rescale import *

--- a/vodesfunc/rescale_ext/ignoremask.py
+++ b/vodesfunc/rescale_ext/ignoremask.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from vskernels import Kernel, KernelLike, Lanczos
+from vstools import ColorRange, CustomValueError, get_lowest_value, get_peak_value, scale_value, vs
+
+from .base import RescaleBase
+
+__all__ = ["DescaleDirection", "IgnoreMask"]
+
+
+class DescaleDirection(StrEnum):
+    """The direction the descale is performed in."""
+
+    HORIZONTAL = "X"
+    """Descale is performed horizontally (ex. 1920x1080 => 1280x1080)"""
+
+    VERTICAL = "Y"
+    """Descale is performed vertically (ex. 1920x1080 => 1920x720)"""
+
+    @classmethod
+    def from_ref(cls, src: vs.VideoNode | tuple[int, int], width: int, height: int) -> DescaleDirection:
+        """Get the direction from a reference."""
+
+        if isinstance(src, vs.VideoNode):
+            src = (src.width, src.height)
+
+        assert isinstance(src, tuple) and all(int(x) for x in src), "You must pass a tuple of ints or a VideoNode!"
+
+        if src == (width, height):
+            raise CustomValueError("Reference dimensions are the same as the output dimensions!", cls.from_ref)
+
+        if src[0] != width and src[1] == height:
+            return cls.HORIZONTAL
+        elif src[0] == width and src[1] != height:
+            return cls.VERTICAL
+
+        raise CustomValueError("Cannot determine descale direction from given dimensions!", cls.from_ref)
+
+    @property
+    def expr_size(self) -> str:
+        """Get the size expr param"""
+
+        if self == DescaleDirection.VERTICAL:
+            return "height"
+
+        return "width"
+
+
+class IgnoreMask(RescaleBase):
+    def _clipping_mask(
+        self,
+        clip: vs.VideoNode,
+        width: int,
+        height: int,
+        direction: DescaleDirection = DescaleDirection.HORIZONTAL,
+        kernel: KernelLike = Lanczos,
+    ) -> vs.VideoNode:
+        """Create a clipping mask to pass to descale as an ignore_mask."""
+
+        kernel = Kernel.ensure_obj(kernel)
+
+        scale_factor = clip.width / width if direction == DescaleDirection.HORIZONTAL else clip.height / height
+        threshold = scale_value(get_peak_value(clip, range_in=ColorRange.LIMITED) - 8, 8, 32, scale_offsets=True)
+        kernel_radius = kernel.kernel_radius * scale_factor
+
+        return clip.akarin.Expr(
+            f"x {threshold} >= "
+            f"{direction.expr_size} {direction.value} - {kernel_radius + 1} < "
+            f"{direction.value} {kernel_radius} < or and "
+            f"{get_peak_value(8, range_in=ColorRange.FULL)} "
+            f"{get_lowest_value(8, range_in=ColorRange.FULL)} ?",
+            format=vs.GRAY8,
+        )


### PR DESCRIPTION
Currently, `ignore_mask` does not work nicely because it can only be used in a single direction (so for example, you must descale vertically only). While the user can call the `RescaleBuilder.descale` method multiple times, this seems to break other methods in the call (such as `error_mask`).

I added a simple clipping mask (that should be used if the user sets `ignore_mask=True` in the `Kernel` they pass, but that has not been implemented yet), and later on intend to somehow figure out how to modify the clip attributes in such a way that error masking doesn't flat-out break.